### PR TITLE
Delete split fatality column

### DIFF
--- a/function/constants/address-details-columns.js
+++ b/function/constants/address-details-columns.js
@@ -60,9 +60,6 @@ module.exports = Object.freeze({
         'q-rep-postcode': 'post_code'
     },
     DCA: {
-        'q-deceased-title': 'dec_title',
-        'q-deceased-first-name': 'dec_first_name',
-        'q-deceased-last-name': 'dec_last_name',
         'q-deceased-building-and-street': 'address_line_1',
         'q-deceased-building-and-street-2': 'address_line_2',
         'q-deceased-building-and-street-3': 'address_line_3',

--- a/function/resources/testing/check-your-answers-sample.json
+++ b/function/resources/testing/check-your-answers-sample.json
@@ -1,7 +1,8 @@
 {
     "meta": {
         "caseReference": "23\\327507",
-        "submittedDate": "2023-05-19T13:06:12.693Z"
+        "submittedDate": "2023-05-19T13:06:12.693Z",
+        "splitFuneral": true
     },
     "themes": [
         {
@@ -684,7 +685,11 @@
                     "label": "Enter their date of birth",
                     "value": "1970-01-01T00:00:00.000Z",
                     "sectionId": "p-deceased-date-of-birth",
-                    "theme": "deceased"
+                    "theme": "deceased",
+                    "format": {
+                        "value": "date-time",
+                        "precision": "YYYY-MM-DD"
+                    }
                 },
                 {
                     "id": "q-deceased-date-of-death",
@@ -692,7 +697,11 @@
                     "label": "Enter their date of death",
                     "value": "2019-01-01T00:00:00.000Z",
                     "sectionId": "p-deceased-date-of-death",
-                    "theme": "deceased"
+                    "theme": "deceased",
+                    "format": {
+                        "value": "date-time",
+                        "precision": "YYYY-MM-DD"
+                    }
                 },
                 {
                     "id": "deceased-address",

--- a/function/services/application-mapper/application-question.js
+++ b/function/services/application-mapper/application-question.js
@@ -154,9 +154,13 @@ function mapApplicationQuestion(data, applicationForm, addressDetails) {
 
             // Split fatal/funeral applications
             case data.id === 'q-applicant-claim-type': {
-                columnValue = applicationForm?.split_funeral
-                    ? ['FuneralOnly', 7]
-                    : ['FatalityOnly', 4];
+                if (applicationForm?.split_funeral) {
+                    columnValue = ['FuneralOnly', 7];
+                    // Not ideal, if we need to delete other fields from the form in future, then we should consider a better approach
+                    delete applicationForm?.split_funeral;
+                } else {
+                    columnValue = ['FatalityOnly', 4];
+                }
                 break;
             }
             // The Crime didnt happen in England, Scotland or Wales


### PR DESCRIPTION
- Split fatality column is deleted after it is checked so it doesn't get inserted into tariff
- Changed dec_last_name and dec_first_name to map to application_form  as the column doesnt exist in address_details