### PR TITLE
Improve injury code eligibility logic

### DIFF
--- a/function/services/eligibility-checker/index.js
+++ b/function/services/eligibility-checker/index.js
@@ -42,8 +42,8 @@ function checkEligibility(applicationFormJson) {
     // We skip this check if the claim is a fatality
     let ineligibleDueToInjuries = false;
     if (
-        (applicationFormJson?.injury_details_code && applicationFormJson?.application_type === 2) ||
-        applicationFormJson?.application_type === 3
+        applicationFormJson?.injury_details_code &&
+        (applicationFormJson?.application_type === 2 || applicationFormJson?.application_type === 3)
     ) {
         ineligibleDueToInjuries = true;
         const injuryCodes = applicationFormJson.injury_details_code.split(':');

--- a/function/services/eligibility-checker/index.js
+++ b/function/services/eligibility-checker/index.js
@@ -22,7 +22,7 @@ function checkEligibility(applicationFormJson) {
     const reportedToPolice = applicationFormJson?.incident_rep_police === 'N';
     // 2. The applicant is not a victim of human trafficking and not seeking asylum
     const traffickedAndSeekingAsylum =
-        applicationFormJson?.residency_9 === 'N' && applicationFormJson?.residency_10 === 'N';
+        applicationFormJson?.residency_09 === 'N' && applicationFormJson?.residency_10 === 'N';
     // 3. The crime was reported 48 hours after the crime happened or started
     const reportedOnTime =
         dateTimePolFirstTold &&
@@ -39,8 +39,13 @@ function checkEligibility(applicationFormJson) {
     // 6. The crime did not happen in England, Scotland or Wales
     const ineligibleLocation = applicationFormJson?.incident_country === 'somewhere-else';
     // 7. The applicant is ineligible if only claiming for certain injuries
-    let ineligibleDueToInjuries = true;
-    if (applicationFormJson?.injury_details_code) {
+    // We skip this check if the claim is a fatality
+    let ineligibleDueToInjuries = false;
+    if (
+        (applicationFormJson?.injury_details_code && applicationFormJson?.application_type === 2) ||
+        applicationFormJson?.application_type === 3
+    ) {
+        ineligibleDueToInjuries = true;
         const injuryCodes = applicationFormJson.injury_details_code.split(':');
         injuryCodes.forEach(code => {
             if (!invalidInjuryCodes.includes(code)) {

--- a/function/services/eligibility-checker/index.test.js
+++ b/function/services/eligibility-checker/index.test.js
@@ -6,16 +6,36 @@ describe('Eligibility checker', () => {
     it('Should be eligible when all checks pass', () => {
         const applicationObject = {
             case_reference_number: '027906',
+            application_type: 2,
             created_date: '02-JAN-22',
             is_eligible: 'Y',
             incident_rep_police: 'Y',
-            residency_9: 'Y',
+            residency_09: 'Y',
             residency_10: 'N',
             date_time_of_incident: '15-FEB-22',
             date_time_pol_first_told: '16-FEB-22',
             date_time_of_incident_to: '10-JAN-23',
             incident_country: 'england',
             injury_details_code: 'phyinj-048:phyinj-001:phyinj-149'
+        };
+        const checkedApplicationObject = checkEligibility(applicationObject);
+        expect(checkedApplicationObject.is_eligible).toBe('Y');
+    });
+
+    it('Should skip injury checking when claim is a fatality', () => {
+        const applicationObject = {
+            case_reference_number: '027906',
+            application_type: 4,
+            created_date: '02-JAN-22',
+            is_eligible: 'Y',
+            incident_rep_police: 'Y',
+            residency_09: 'Y',
+            residency_10: 'N',
+            date_time_of_incident: '15-FEB-22',
+            date_time_pol_first_told: '16-FEB-22',
+            date_time_of_incident_to: '10-JAN-23',
+            incident_country: 'england',
+            injury_details_code: 'phyinj-149'
         };
         const checkedApplicationObject = checkEligibility(applicationObject);
         expect(checkedApplicationObject.is_eligible).toBe('Y');
@@ -37,7 +57,7 @@ describe('Eligibility checker', () => {
             case_reference_number: '027906',
             created_date: '02-JAN-23',
             is_eligible: 'Y',
-            residency_9: 'N',
+            residency_09: 'N',
             residency_10: 'N'
         };
         const checkedApplicationObject = checkEligibility(applicationObject);
@@ -92,6 +112,7 @@ describe('Eligibility checker', () => {
     it('Should be ineligible if all the injury codes are ineligible', () => {
         const applicationObject = {
             case_reference_number: '027906',
+            application_type: 2,
             created_date: '02-JAN-22',
             is_eligible: 'Y',
             injury_details_code: 'phyinj-149:phyinj-044:phyinj-048'


### PR DESCRIPTION
If the claim is a fatality, the injury code list is null. We need to skip the injury eligibility checking if the claim is a fatality