### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CriminalInjuriesCompensationAuthority/tempus-broker/security/code-scanning/1](https://github.com/CriminalInjuriesCompensationAuthority/tempus-broker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` to the least privileges required. Since this workflow only installs dependencies and runs tests, it does not require any write permissions. The minimal permission required is `contents: read`, which allows the workflow to read the repository contents.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
